### PR TITLE
feat: modify env interface with Symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a library that lets you bundle an MCP server setup easily.
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 
 import { createServer } from "@wrtnlabs/calculator-mcp";
-import { bundler } from "@wrtnlabs/mcp-bundler";
+import { bundler, RequiredEnv } from "@wrtnlabs/mcp-bundler";
 
 export const server: Server = bundler({
   name: "The cool Server",
@@ -22,7 +22,11 @@ export const server: Server = bundler({
       args: [
         "--watch",
         "/path/to/figma-mcp/src/index.ts",
-      ]
+      ],
+      env: {
+        FIGMA_PERSONAL_ACCESS_TOKEN: RequiredEnv,
+        PORT: RequiredEnv,
+      },
     },
     calculator: createServer({
       name: "calculator",
@@ -32,15 +36,10 @@ export const server: Server = bundler({
       command: "npx",
       args: ["-y", "@notionhq/notion-mcp-server"],
       env: {
-        OPENAPI_MCP_HEADERS: "{\"Authorization\": \"Bearer ntn_****\", \"Notion-Version\": \"2022-06-28\" }"
-      }
+        OPENAPI_MCP_HEADERS: RequiredEnv,
+      },
     },
   },
-  env: {
-    OPENAPI_MCP_HEADERS: "notionApi",
-    FIGMA_PERSONAL_ACCESS_TOKEN: "figma",
-    PORT: "figma",
-  }
 })();
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { connectMcp } from "./mcp.js";
 import { createServer } from "./server";
 import { startSSEServer } from "./sse";
 
-export function buildCli<T extends Record<string, McpConnection>>(props: { version: string; name: string; mcpServers: T; env: Record<string, keyof T> }) {
+export function buildCli<T extends Record<string, McpConnection>>(props: { version: string; name: string; mcpServers: T }) {
   return new Command()
     .version(props.version)
     .name(props.name)
@@ -21,8 +21,7 @@ export function buildCli<T extends Record<string, McpConnection>>(props: { versi
       await connectMcp({
         adapter,
         mcpServers: props.mcpServers,
-        env: props.env,
-        envMapper: process.env as Record<string, string>,
+        externalEnv: process.env as Record<string, string>,
       });
 
       if (typeof options === "object" && options !== null && "port" in options && (typeof options.port === "string" || typeof options.port === "number")) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,7 +34,6 @@ describe("bundler", () => {
         mcpServers: {
           test: mockServer,
         },
-        env: {},
       });
 
       client = new Client({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 import type { McpConnection } from "./mcp";
 
-import { buildCli } from "./cli";
 import { connectMcp } from "./mcp";
+import { buildCli } from "./cli";
 import { createServer } from "./server";
 
 interface Props<T extends Record<string, McpConnection>> {
@@ -50,3 +50,5 @@ export function bundler<const T extends Record<string, McpConnection>>(props: Pr
     },
   };
 }
+
+export { RequiredEnv, OptionalEnv } from "./mcp";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ interface Props<T extends Record<string, McpConnection>> {
   name: string;
   version: string;
   mcpServers: T;
-  env: Record<string, keyof T>;
 }
 
 export function bundler<const T extends Record<string, McpConnection>>(props: Props<T>): {
@@ -25,7 +24,6 @@ export function bundler<const T extends Record<string, McpConnection>>(props: Pr
         name: props.name,
         version: props.version,
         mcpServers: props.mcpServers,
-        env: props.env,
       }).parse(process.argv);
     },
     createServer: async (envList: Record<string, string>) => {
@@ -33,12 +31,15 @@ export function bundler<const T extends Record<string, McpConnection>>(props: Pr
         name: props.name,
         version: props.version,
       });
+      const env = {
+        ...process.env,
+        ...envList,
+      } as Record<string, string>;
 
       await connectMcp({
         adapter,
         mcpServers: props.mcpServers,
-        envMapper: envList,
-        env: props.env,
+        externalEnv: env,
       });
 
       return createServer({

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -1,10 +1,26 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { connectMcp } from "./mcp";
+import { connectMcp, RequiredEnv } from "./mcp";
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", async () => {
+  const actual = await vi.importActual<typeof import("@modelcontextprotocol/sdk/client/stdio.js")>(
+    "@modelcontextprotocol/sdk/client/stdio.js",
+  );
+  return {
+    ...actual,
+    // eslint-disable-next-line ts/no-unsafe-argument
+    StdioClientTransport: vi.fn().mockImplementation(config => new actual.StdioClientTransport(config)),
+  };
+});
 
 describe("connectMcp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should connect to InMemory MCP server", async () => {
     const server = new Server({
       name: "test-server",
@@ -21,40 +37,47 @@ describe("connectMcp", () => {
       mcpServers: {
         test: server,
       },
-      env: {},
-      envMapper: {},
+      externalEnv: {},
     });
 
     expect(adapter.transport).toBeDefined();
   });
 
   it("should handle environment variables correctly", async () => {
-    const server = new Server({
-      name: "test-server",
-      version: "1.0.0",
-    });
-
     const adapter = new Client({
       name: "test-client",
       version: "1.0.0",
     });
 
-    const envMapper = {
+    const testEnv = {
       TEST_KEY: "test_value",
+      ANOTHER_KEY: "another_value",
     };
 
     await connectMcp({
       adapter,
       mcpServers: {
-        test: server,
+        test: {
+          command: "npx",
+          args: ["-y", "@wrtnlabs/calculator-mcp@latest"],
+          env: {
+            TEST_KEY: RequiredEnv,
+            ANOTHER_KEY: RequiredEnv,
+          },
+        },
       },
-      env: {
-        TEST_KEY: "test",
-      },
-      envMapper,
+      externalEnv: testEnv,
     });
 
-    expect(process.env.TEST_KEY).toBe("test_value");
+    expect(StdioClientTransport).toHaveBeenCalled();
+
+    // eslint-disable-next-line ts/no-unsafe-assignment, ts/no-unsafe-member-access
+    const lastCall = (StdioClientTransport as any).mock.calls[0][0];
+    // eslint-disable-next-line ts/no-unsafe-member-access
+    expect(lastCall.env.ANOTHER_KEY).toBe("another_value");
+    // eslint-disable-next-line ts/no-unsafe-member-access
+    expect(lastCall.env.TEST_KEY).toBe("test_value");
+    await adapter.close();
   });
 
   it("should handle multiple MCP servers", async () => {
@@ -79,10 +102,10 @@ describe("connectMcp", () => {
         test1: server1,
         test2: server2,
       },
-      env: {},
-      envMapper: {},
+      externalEnv: {},
     });
 
     expect(adapter.transport).toBeDefined();
+    await adapter.close();
   });
 });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,10 +6,16 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 
+export const RequiredEnv = Symbol("_mcp_bundler_required_env");
+//            ^?
+export const OptionalEnv = Symbol("_mcp_bundler_optional_env");
 export interface SSEMcpConnection {
   url: URL;
 }
-export type StdioMcpConnection = StdioServerParameters;
+export type StdioMcpConnection = Omit<StdioServerParameters, "env"> & {
+  env?: Record<string, typeof RequiredEnv | typeof OptionalEnv | string>;
+};
+
 export type InMemoryMcpConnection = Server;
 export type McpConnection = SSEMcpConnection | StdioMcpConnection | InMemoryMcpConnection;
 
@@ -21,14 +27,11 @@ export type McpConnection = SSEMcpConnection | StdioMcpConnection | InMemoryMcpC
 export async function connectMcp<const T extends Record<string, McpConnection>>(props: {
   adapter: Client;
   mcpServers: T;
-  envMapper: Record<string, string>;
-  env: Record<string, keyof T>;
+  externalEnv: Record<string, string>;
 }) {
   const transports = await Promise.all(Object.entries(props.mcpServers).map(async ([name, setting]) => {
     // InMemory
     if (setting instanceof Server) {
-      const env = extractEnvFromName(name, props.env, props.envMapper);
-      Object.assign(process.env, env);
       const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
       await setting.connect(serverTransport);
       return clientTransport;
@@ -41,8 +44,12 @@ export async function connectMcp<const T extends Record<string, McpConnection>>(
 
     // Stdio
     if ("command" in setting) {
-      const env = extractEnvFromName(name, props.env, props.envMapper);
+      const env = extractEnvFromName({
+        env: setting.env ?? {},
+        externalEnv: props.externalEnv,
+      });
 
+      Object.assign(env, process.env);
       return new StdioClientTransport({
         ...setting,
         env: Object.keys(env).length !== 0 ? env : undefined,
@@ -64,17 +71,30 @@ export async function connectMcp<const T extends Record<string, McpConnection>>(
 /**
  * Extracts the environment variables from the name.
  *
- * @param name - The name of the MCP server.
- * @param env - The environment variables. { ENV_KEY: "ENV_TARGET" }
- * ENV_TARGET is the target environment variable name, so example: "slack", "notion", "github", etc.
- * @param envMapper - The environment variable mapper. { ENV_KEY: "ENV_VALUE" }
+ * @param props - The properties.
+ * @param props.env - The environment variables written by hard coding.
+ * @param props.externalEnv - The environment variables. { ENV_KEY: "ENV_VALUE" }
  * ENV_VALUE is the value of the environment variable, so example: "gh_12309wqje123", "nt_12309wqje123", etc.
  * @returns The environment variables.
  */
-function extractEnvFromName<const T extends Record<string, McpConnection>>(name: string, env: Record<string, keyof T>, envMapper: Record<string, string>) {
-  return Object.fromEntries(
-    Object.entries(env)
-      .filter(([, value]) => value === name)
-      .map(([key]) => [key, envMapper[key]]),
-  );
+function extractEnvFromName(props: {
+  env: Record<string, typeof RequiredEnv | typeof OptionalEnv | string>;
+  externalEnv: Record<string, string>;
+}) {
+  const envEntries = Object.entries(props.env);
+  const defaultEnv = envEntries.filter(([, value]) => typeof value === "string") as [string, string][];
+  const requiredEnv = envEntries.filter(([, value]) => value === RequiredEnv).map(([key]) => [key, props.externalEnv[key]] as const);
+  const optionalEnv = envEntries.filter(([, value]) => value === OptionalEnv).map(([key]) => [key, props.externalEnv[key]] as const);
+
+  requiredEnv.forEach(([key, value]) => {
+    if (value === undefined) {
+      console.warn(`Required environment variable ${key} is not set.`);
+    }
+  });
+
+  return {
+    ...Object.fromEntries(defaultEnv),
+    ...Object.fromEntries(requiredEnv),
+    ...Object.fromEntries(optionalEnv),
+  };
 }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -3,6 +3,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
 
 import { createServer } from "./server";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 describe("createServer", () => {
   it("should create a server instance", () => {
@@ -16,40 +17,66 @@ describe("createServer", () => {
       version: "1.0.0",
       adapter: client,
     });
-
     expect(server).toBeDefined();
+    server.close();
   });
 
   it("should handle tool listing requests", async () => {
-    const client = new Client({
-      name: "test-client",
+    const _client = new Client({
+      name: "calculator-client",
       version: "1.0.0",
     });
+
+    const _stdioTransport = new StdioClientTransport({
+      command: "npx",
+      args: ["-y", "@wrtnlabs/calculator-mcp@latest"],
+    });
+
+    await _client.connect(_stdioTransport);
 
     const server = createServer({
       name: "test-server",
       version: "1.0.0",
-      adapter: client,
+      adapter: _client,
     });
 
+    const client = new Client({
+      name: "test-client",
+      version: "1.0.0",
+    });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
     await client.connect(clientTransport);
-
     const tools = await client.listTools();
+    
     expect(tools).toBeDefined();
+    await _client.close();
+    await client.close();
+    await server.close();
   });
 
   it("should handle tool call requests", async () => {
-    const client = new Client({
-      name: "test-client",
+    const _client = new Client({
+      name: "calculator-client",
       version: "1.0.0",
     });
+
+    const _stdioTransport = new StdioClientTransport({
+      command: "npx",
+      args: ["-y", "@wrtnlabs/calculator-mcp@latest"],
+    });
+
+    await _client.connect(_stdioTransport);
 
     const server = createServer({
       name: "test-server",
       version: "1.0.0",
-      adapter: client,
+      adapter: _client,
+    });
+
+    const client = new Client({
+      name: "test-client",
+      version: "1.0.0",
     });
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -62,5 +89,7 @@ describe("createServer", () => {
     });
 
     expect(result).toBeDefined();
+    await client.close();
+    await server.close();
   });
 });


### PR DESCRIPTION
This pull request introduces a significant refactor to the handling of environment variables and improves testing for MCP (Model Context Protocol) connections and server interactions. The main changes include replacing the `env` and `envMapper` properties with a unified `externalEnv` property, adding support for required and optional environment variables, and enhancing test coverage with mock implementations and additional assertions.

### Refactor of Environment Variable Handling:

* Replaced `env` and `envMapper` with `externalEnv` in `connectMcp` and related functions to streamline environment variable management (`src/cli.ts`, `src/index.ts`, `src/mcp.ts`). [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL11-R11) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL24-R24) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L15) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L28-R42) [[5]](diffhunk://#diff-fc9de229ce5f3d13e6aecbd13523790e3b08d068bd65c73036688ae1f0dfabe3L24-L31)
* Introduced `RequiredEnv` and `OptionalEnv` symbols to differentiate between mandatory and optional environment variables in `StdioMcpConnection` (`src/mcp.ts`).
* Updated `extractEnvFromName` to handle required and optional environment variables, logging warnings for missing required variables (`src/mcp.ts`).

### Test Enhancements:

* Added mocks for `StdioClientTransport` and improved test coverage for `connectMcp`, including handling of required/optional environment variables and multiple MCP servers (`src/mcp.test.ts`). [[1]](diffhunk://#diff-a61a4b7ab1e926e9570624e7f2d77137282c090d355651ae52aabd7468cb3240R2-R23) [[2]](diffhunk://#diff-a61a4b7ab1e926e9570624e7f2d77137282c090d355651ae52aabd7468cb3240L24-R80) [[3]](diffhunk://#diff-a61a4b7ab1e926e9570624e7f2d77137282c090d355651ae52aabd7468cb3240L82-R109)
* Enhanced `createServer` tests to include cleanup of resources (e.g., closing clients and servers) and added tests for tool listing and tool call requests (`src/server.test.ts`). [[1]](diffhunk://#diff-99636b5e2b3a9100df9b2079be55b305abba16b491d8829b53f423a47e8b8d31R6) [[2]](diffhunk://#diff-99636b5e2b3a9100df9b2079be55b305abba16b491d8829b53f423a47e8b8d31L19-R79) [[3]](diffhunk://#diff-99636b5e2b3a9100df9b2079be55b305abba16b491d8829b53f423a47e8b8d31R92-R93)